### PR TITLE
Add struct keyword to internalAccelState in accel_state.

### DIFF
--- a/src/accel.h
+++ b/src/accel.h
@@ -21,7 +21,7 @@ struct internalAccelState;
 typedef struct {
     int dimensions;
 
-    internalAccelState *state;
+    struct internalAccelState *state;
 } accel_state;
 
 /**


### PR DESCRIPTION
Pebble compiler complains about not having the keyword.
