### PR TITLE
Made up for the pebble's lack of implementing calloc and realloc.

### DIFF
--- a/src/accel.c
+++ b/src/accel.c
@@ -6,6 +6,10 @@
 
 #ifdef PEBBLE
 #include <pebble.h>
+#include <pebble_makeup.h>
+#else
+#define my_realloc(a, b, c) realloc(a, b)
+#define my_calloc(a, b) calloc(a, b)
 #endif
 
 #ifndef INT16_MAX
@@ -117,7 +121,7 @@ int accel_generate_gesture(accel_state *state, accel_gesture **gesture) {
     (*gesture)->is_recorded = false;
     (*gesture)->normalized_recording = NULL;
 
-    (*gesture)->moving_avg_values = (moving_avg_values **) calloc(state->dimensions, sizeof(moving_avg_values *));
+    (*gesture)->moving_avg_values = (moving_avg_values **) my_calloc(state->dimensions, sizeof(moving_avg_values *));
     if ((*gesture)->moving_avg_values == NULL) {
         free((*gesture));
         *gesture = NULL;
@@ -212,7 +216,7 @@ int accel_start_record_gesture(accel_state *state, int *gesture) {
     PRECONDITION_NOT_NULL(gesture);
 
     if (state->state->num_gestures_saved != 0) {
-        accel_gesture **tmp = (accel_gesture **)realloc(state->state->gestures, (state->state->num_gestures_saved + 1)*sizeof(accel_gesture *));
+        accel_gesture **tmp = (accel_gesture **)my_realloc(state->state->gestures, (state->state->num_gestures_saved + 1)*sizeof(accel_gesture *), (state->state->num_gestures_saved)*sizeof(accel_gesture *));
         if (tmp == NULL) {
             return ACCEL_MALLOC_ERROR;
         }
@@ -234,7 +238,7 @@ int accel_start_record_gesture(accel_state *state, int *gesture) {
             free(state->state->gestures);
             state->state->gestures = NULL;
         } else {
-            accel_gesture ** tmp = (accel_gesture **)realloc(state->state->gestures, state->state->num_gestures_saved - 1);
+            accel_gesture ** tmp = (accel_gesture **)my_realloc(state->state->gestures, state->state->num_gestures_saved - 1, state->state->num_gestures_saved);
             if (tmp != NULL) {
                 // If tmp is null, we don't really care that realloc failed, since a future use of realloc will help us.
                 state->state->gestures = tmp;
@@ -304,7 +308,7 @@ void handle_recording_tick(accel_gesture *gesture, int dimensions) {
     if (gesture == NULL) { return; }
     // TODO: grow exponentially, not linearly. Linear growth allocates too frequently.
     if (gesture->recording_size != 0) {
-        gesture->normalized_recording = (int **) realloc(gesture->normalized_recording, (gesture->recording_size + 1) * sizeof(int *));
+        gesture->normalized_recording = (int **) my_realloc(gesture->normalized_recording, (gesture->recording_size + 1) * sizeof(int *), gesture->recording_size * sizeof(int *));
         if (gesture->normalized_recording == NULL) {
             return;
         }

--- a/src/pebble_makeup.h
+++ b/src/pebble_makeup.h
@@ -1,0 +1,36 @@
+#ifndef ACCEL_PEBBLE_SUPPLEMENTARY
+#define ACCEL_PEBBLE_SUPPLEMENTARY
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+void *my_realloc(void *old_ptr, size_t new_size, size_t old_size) {
+    if (new_size == old_size) {
+        return old_ptr;
+    }
+    if (old_ptr == NULL && old_size != 0) {
+        return NULL;
+    }
+    if (new_size == 0) {
+        free(old_ptr);
+        return malloc(new_size);
+    }
+    void *p = malloc(new_size);
+
+    if (!p) return NULL;
+
+    size_t min_size = new_size < old_size ? new_size : old_size;
+    memcpy(p, old_ptr, min_size);
+    free(old_ptr);
+    return p;
+}
+
+void *my_calloc(size_t num, size_t size) {
+    void * allocd = malloc(num * size);
+    if (allocd == NULL) return allocd;
+    memset(allocd, 0, num * size);
+    return allocd;
+}
+
+#endif


### PR DESCRIPTION
Quick and dirty implementation of calloc and realloc, to make up for
Pebble's lack of realloc and calloc methods.

Their response to me asking for endpoints:

> Not in the short term. Our memory heap implementation is simple and
> those would not be very optimized. It is probably better to do it
> yourself if you really need that type of feature. We want to avoid
> people relying on them and expecting them to be very optimized.

I don't necessarily agree with them, but it looks like it needs to be
re-implemented.
