### PR TITLE
Removed unused include directive for accel_consts.c

### DIFF
--- a/sample/simple-accelerometer/src/accel.h
+++ b/sample/simple-accelerometer/src/accel.h
@@ -3,8 +3,6 @@
 
 #include <stdbool.h>
 
-#include "accel_consts.c"
-
 #define ACCEL_SUCCESS 0
 #define ACCEL_PARAM_ERROR -1
 #define ACCEL_INTERNAL_ERROR -2


### PR DESCRIPTION
Essentially, after overwriting all the files and letting Git do a diff, it comes down to just removing this include directive. :+1: 
